### PR TITLE
ui/editor: Undo should teleport

### DIFF
--- a/ui/editor/editor.go
+++ b/ui/editor/editor.go
@@ -606,6 +606,7 @@ func (e *Editor) undo() {
 	eb := e.buffers.Get(e.activebuf)
 	if res := eb.Buffer.UndoModification(); res != nil {
 		eb.Update(*res)
+		eb.Viewport.SetTeleported(eb.CursorLine())
 		// XXX We reanalyse the whole file after undo.
 		e.sethighlighting()
 	}


### PR DESCRIPTION
We recently simplified our scrolling algorithm, which also broke
the implicit multipage scroll towards our undo location. Now we
explicitly teleport once undo is performed.