### PR TITLE
viewport: Avoid viewport move if new line already visible

### DIFF
--- a/ui/editor/editor.go
+++ b/ui/editor/editor.go
@@ -479,7 +479,6 @@ func (e *Editor) replace() {
 		e.setmodified(true)
 		e.highlightline(lineno)
 	}
-
 }
 
 func (e *Editor) search() {

--- a/viewport/viewport.go
+++ b/viewport/viewport.go
@@ -440,7 +440,9 @@ func (v *Viewport) PageDown() int {
 	return v.y0
 }
 
-func (v *Viewport) SetTeleported(y0 int) {
-	v.paged = true
-	v.y0 = y0
+func (v *Viewport) SetTeleported(y int) {
+	v.paged = y < v.y0 || y > v.limitdown
+	if v.paged {
+		v.y0 = y
+	}
 }


### PR DESCRIPTION
This seemingly trivial change gets rid of most of the annoying
surprise translations for the viewport.